### PR TITLE
feat: Option for not saving alignment files (Security)

### DIFF
--- a/q2_bowtie2/_bowtie.py
+++ b/q2_bowtie2/_bowtie.py
@@ -1,3 +1,4 @@
+import gzip
 import os
 import subprocess
 import tempfile
@@ -91,6 +92,7 @@ def align_single(
     bowtie_database: Bowtie2IndexDirFmt,
     demultiplexed_sequences: SingleLanePerSampleSingleEndFastqDirFmt,
     threads: int = 1,
+    save_alignment: bool = False,
 ) -> (CasavaOneEightSingleLanePerSampleDirFmt, CasavaOneEightSingleLanePerSampleDirFmt, BAMDirFmt):  # type: ignore
     """align_single.
 
@@ -102,6 +104,8 @@ def align_single(
         demultiplexed_sequences
     threads : int, optional
         number of alignment threads to launch. Defaults to 1.
+    save_alignment : bool, optional
+        Whether to save alignment files. Defaults to False.
 
     Returns
     -------
@@ -128,6 +132,27 @@ def align_single(
         ]
         with tempfile.NamedTemporaryFile() as temp:
             subprocess.run(cmd, check=True, stdout=temp)
+        if not save_alignment:
+            file_path = os.path.basename(sample_path)
+            # Making an empty fastq file per sample
+            with gzip.open(os.path.join(str(aligned_filtered_seqs), file_path), "w") as f1:
+                pass
+            # Making an empty bam file per sample
+            tmp_sam_file = "empty.same"
+            header_content = """@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:1\tLN:8
+@PG\tID:bowtie2\tPN:bowtie2\tVN:2.3.4.1\tCL:"/usr/bin/bowtie2-align-s --wrapper basic-0 -x dummyref.fa -f dummyquery.fa"
+A\t4\t*\t0\t0\t*\t*\t0\t0\tTTTTTTTT\tIIIIIIII\tYT:Z:UU\n"""
+            with open(tmp_sam_file, "w") as header_file:
+                header_file.write(header_content)
+            with open(os.path.join(str(bowtie_alignment), f"{sample_id}.bam"), "w") as bowtie_file:
+                subprocess.run(
+                    ["samtools", "view", "-bS", "empty.sam"],
+                    check=True,
+                    stdout=bowtie_file,
+                )
+            os.remove(tmp_sam_file)
+
+        else:
             with open(os.path.join(str(bowtie_alignment), f"{sample_id}.bam"), "w") as bowtie_file:
                 subprocess.run(["samtools", "view", "-bS", temp.name], check=True, stdout=bowtie_file)
 

--- a/q2_bowtie2/plugin_setup.py
+++ b/q2_bowtie2/plugin_setup.py
@@ -9,7 +9,7 @@ from q2_types.per_sample_sequences import (
 )
 from q2_types.sample_data import SampleData
 from q2_types_genomics.per_sample_data._type import AlignmentMap
-from qiime2.plugin import Int
+from qiime2.plugin import Bool, Int
 
 import q2_bowtie2
 
@@ -46,14 +46,17 @@ plugin.methods.register_function(
         "bowtie_database": Bowtie2Index,
         "demultiplexed_sequences": SampleData[SequencesWithQuality],  # type: ignore
     },
-    parameters={"threads": Int},
+    parameters={"threads": Int, "save_alignment": Bool},
     outputs=[
         ("aligned_reads", SampleData[SequencesWithQuality]),  # type: ignore
         ("unaligned_reads", SampleData[SequencesWithQuality]),  # type: ignore
         ("bowtie2_alignment", SampleData[AlignmentMap]),  # type: ignore
     ],  # type: ignore
     input_descriptions={},
-    parameter_descriptions={"threads": "number of alignment threads to launch"},
+    parameter_descriptions={
+        "threads": "number of alignment threads to launch",
+        "save_alignment": "Whether to save alignment files",
+    },
     output_descriptions={},
     name="bowtie2 qiime plugin",
     description=("Description of bowtie2.align"),


### PR DESCRIPTION
Added a parameter for not saving alignment files when running bowtie2.
This is an important feature for biomefx as we shouldn't save the aligned human genome as we would thus keep the human dna.
My first though was that qiime would support optional outputs, but that is apparently a work in progress.
Then I had two different solutions:
1. Output empty files when we shouldn't save the alignment files (recommended practice here: https://forum.qiime2.org/t/specify-when-output-if-optional-vs-required/19541)
2. Register a new function called align_single_without_alignment_files or something similar. That would call the _align_single function and then just output the unaligned files.

I went with option 1, but let me know what you think.